### PR TITLE
Feature/add arn function for production usage

### DIFF
--- a/clients/python/.env.example
+++ b/clients/python/.env.example
@@ -1,2 +1,3 @@
 KINDO_MESSAGE_PRODUCER_URL="<ask kindo dev team to get the producer url>"
+KINDO_MESSAGE_PRODUCER_ARN="<ask kindo dev team to get the producer arn>"
 KINDO_MESSAGE_BEHAVIOR="instant"

--- a/clients/python/README.md
+++ b/clients/python/README.md
@@ -177,7 +177,6 @@ Sends a structured message to the Kindo Producer Lambda via direct ARN invocatio
 - `arn` (str): The Lambda function ARN
 - `message` (ProducerPayload): The message to send
 - `region` (str, optional): AWS region (default: from environment or "ap-southeast-2")
-- `service` (str, optional): AWS service name (default: from environment or "lambda")
 - `schema_path` (str, optional): Path to JSON schema file (default: built-in schema)
 
 #### Returns

--- a/clients/python/README.md
+++ b/clients/python/README.md
@@ -1,9 +1,10 @@
 # Kindo Python Client
 
-A Python SDK for sending structured messages to the Kindo Producer Lambda service via Function URL with AWS SigV4 authentication.
+A Python SDK for sending structured messages to the Kindo Producer Lambda service via Function URL or direct ARN invocation with AWS SigV4 authentication.
 
 ## Features
 
+- **Dual Invocation Methods**: Send messages via Function URL or direct Lambda ARN invocation, URL for local development purposes, ARN for production.
 - **AWS SigV4 Authentication**: Secure message transmission using AWS credentials
 - **JSON Schema Validation**: Built-in message structure validation
 - **Type Safety**: Full type hints and TypedDict support
@@ -31,8 +32,11 @@ pip install -r requirements.txt
 Create a `.env` file in your project root:
 
 ```bash
-# Required
+# Required (choose one for local development purposes)
 KINDO_MESSAGE_PRODUCER_URL=https://your-lambda-function-url.amazonaws.com
+# OR for production:
+KINDO_MESSAGE_PRODUCER_ARN=arn:aws:lambda:region:account:function:function-name
+
 KINDO_MESSAGE_BEHAVIOR=instant
 
 # Optional (defaults shown)
@@ -51,10 +55,15 @@ Ensure your AWS credentials are properly configured using one of these methods:
 
 ## Usage
 
+### Choosing Between Function URL and ARN
+
+- **Function URL** (`send_to_producer`): Best for local development purposes
+- **ARN** (`send_to_producer_via_arn`): Best for production purposes
+
 ### Basic Example
 
 ```python
-from kindo_message_client.producer import send_to_producer
+from kindo_message_client.producer import send_to_producer, send_to_producer_via_arn
 
 # Message structure
 message = {
@@ -82,10 +91,22 @@ sensitive_message = {
     }
 }
 
-# Send message
+# Send message via Function URL
 try:
     tracking_id = send_to_producer(
         url="https://your-lambda-function-url.amazonaws.com",
+        message=message
+    )
+    print(f"Message sent successfully. Tracking ID: {tracking_id}")
+except ValueError as e:
+    print(f"Validation error: {e}")
+except RuntimeError as e:
+    print(f"Send error: {e}")
+
+# Send message via ARN
+try:
+    tracking_id = send_to_producer_via_arn(
+        arn="arn:aws:lambda:us-east-1:123456789012:function:kindo-producer",
         message=message
     )
     print(f"Message sent successfully. Tracking ID: {tracking_id}")
@@ -127,7 +148,7 @@ tracking_id = send_to_producer(
 
 ### `send_to_producer`
 
-Sends a structured message to the Kindo Producer Lambda.
+Sends a structured message to the Kindo Producer Lambda via Function URL.
 
 #### Parameters
 
@@ -146,6 +167,34 @@ Sends a structured message to the Kindo Producer Lambda.
 - `ValueError`: When message validation fails
 - `RuntimeError`: When message sending fails
 - `ConfigError`: When required environment variables are missing
+
+### `send_to_producer_via_arn`
+
+Sends a structured message to the Kindo Producer Lambda via direct ARN invocation.
+
+#### Parameters
+
+- `arn` (str): The Lambda function ARN
+- `message` (ProducerPayload): The message to send
+- `region` (str, optional): AWS region (default: from environment or "ap-southeast-2")
+- `service` (str, optional): AWS service name (default: from environment or "lambda")
+- `schema_path` (str, optional): Path to JSON schema file (default: built-in schema)
+
+#### Returns
+
+- `str`: Tracking ID returned by the producer service
+
+#### Raises
+
+- `ValueError`: When message validation fails
+- `RuntimeError`: When Lambda invocation fails
+- `ConfigError`: When required environment variables are missing
+
+#### Notes
+
+- Uses `boto3` to invoke the Lambda function directly
+- Handles both direct Lambda response and API Gateway response formats
+- Requires appropriate IAM permissions for Lambda invocation
 
 ### Message Structure
 
@@ -216,7 +265,7 @@ pytest
 
 ```python
 from datetime import datetime
-from kindo_message_client.producer import send_to_producer
+from kindo_message_client.producer import send_to_producer, send_to_producer_via_arn
 
 def send_user_notification(user_id: str, message: str, channel: str, is_sensitive: bool = False):
     payload = {
@@ -236,15 +285,34 @@ def send_user_notification(user_id: str, message: str, channel: str, is_sensitiv
     
     return send_to_producer(PRODUCER_URL, payload)
 
+def send_user_notification_via_arn(user_id: str, message: str, channel: str, is_sensitive: bool = False):
+    payload = {
+        "event_type": "user.notification",
+        "message_channel": channel,
+        "behavior": "instant",
+        "payload": {
+            "user_id": user_id,
+            "message": message,
+            "timestamp": datetime.utcnow().isoformat()
+        }
+    }
+    
+    # Add security level for sensitive notifications
+    if is_sensitive:
+        payload["security_level"] = "sensitive"
+    
+    return send_to_producer_via_arn(PRODUCER_ARN, payload)
+
 # Example usage
 send_user_notification("12345", "Your password has been reset", "email", is_sensitive=True)
+send_user_notification_via_arn("12345", "Your account has been locked", "sms", is_sensitive=True)
 ```
 
 ### Event Logging
 
 ```python
 from datetime import datetime
-from kindo_message_client.producer import send_to_producer
+from kindo_message_client.producer import send_to_producer, send_to_producer_via_arn
 
 def log_system_event(event_type: str, data: dict):
     payload = {
@@ -258,6 +326,23 @@ def log_system_event(event_type: str, data: dict):
     }
     
     return send_to_producer(PRODUCER_URL, payload)
+
+def log_system_event_via_arn(event_type: str, data: dict):
+    payload = {
+        "event_type": f"system.{event_type}",
+        "message_channel": "logging",
+        "behavior": "instant",
+        "payload": {
+            "timestamp": datetime.utcnow().isoformat(),
+            "data": data
+        }
+    }
+    
+    return send_to_producer_via_arn(PRODUCER_ARN, payload)
+
+# Example usage
+log_system_event("authentication", {"user_id": "12345", "action": "login"})
+log_system_event_via_arn("error", {"service": "payment", "error_code": "CARD_DECLINED"})
 ```
 
 ## Troubleshooting
@@ -272,11 +357,17 @@ def log_system_event(event_type: str, data: dict):
    - Verify message structure matches the required schema
    - Check that all required fields are present
 
-3. **Network Errors**
+3. **Network Errors** (Function URL)
    - Verify the Lambda Function URL is correct and accessible
    - Check network connectivity and firewall settings
 
-4. **Configuration Errors**
+4. **Lambda Invocation Errors** (ARN)
+   - Verify the Lambda function ARN is correct
+   - Check that the Lambda function exists and is active
+   - Verify the AWS region matches the function's region
+   - If you are using a local development environment, ensure you have the correct AWS credentials configured
+
+5. **Configuration Errors**
    - Ensure all required environment variables are set
    - Verify the `.env` file is in the correct location
 

--- a/clients/python/producer.py
+++ b/clients/python/producer.py
@@ -41,7 +41,6 @@ def send_to_producer_via_arn(
     arn: str,
     message: ProducerPayload,
     region: str = AWS_REGION,
-    service: str = AWS_SERVICE,
     schema_path: str = SCHEMA_PATH
 ) -> str:
     with open(os.path.join(os.path.dirname(__file__), schema_path)) as f:

--- a/clients/python/requirements.txt
+++ b/clients/python/requirements.txt
@@ -1,4 +1,5 @@
 attrs==25.3.0
+boto3==1.35.45
 botocore==1.38.45
 certifi==2025.6.15
 charset-normalizer==3.4.2

--- a/clients/python/tests/test_producer.py
+++ b/clients/python/tests/test_producer.py
@@ -1,9 +1,11 @@
 import os
+import json
 import pytest
 from unittest.mock import patch, MagicMock
 from .. import producer
 
 PRODUCER_URL = os.getenv("KINDO_MESSAGE_PRODUCER_URL")  # inject this during testing
+PRODUCER_ARN = os.getenv("KINDO_MESSAGE_PRODUCER_ARN")  # inject this during testing
 
 @pytest.fixture
 def valid_message():
@@ -114,4 +116,149 @@ def test_signed_post_success_with_security_level(valid_message_with_security_lev
     """Integration test with security_level field"""
     tracking_id = producer.send_to_producer(PRODUCER_URL, valid_message_with_security_level)
     assert isinstance(tracking_id, str) and len(tracking_id) > 0
+
+
+# Tests for send_to_producer_via_arn
+def test_arn_schema_validation(valid_message):
+    """Test that ARN function validates message schema the same way as URL function"""
+    # Remove a required field to force schema validation failure
+    invalid_message = valid_message.copy()
+    del invalid_message["event_type"]
+    with pytest.raises(ValueError) as exc_info:
+        producer.send_to_producer_via_arn("arn:aws:lambda:us-east-1:123456789012:function:test-function", invalid_message)
+    assert "'event_type' is a required property" in str(exc_info.value)
+
+
+@patch('boto3.client')
+def test_arn_lambda_invocation_success(mock_boto3_client, valid_message):
+    """Test successful Lambda invocation via ARN with mocked boto3"""
+    # Mock the Lambda client and its invoke method
+    mock_lambda_client = MagicMock()
+    mock_boto3_client.return_value = mock_lambda_client
+    
+    # Mock successful response with direct Lambda format
+    mock_response = {
+        'StatusCode': 200,
+        'Payload': MagicMock()
+    }
+    mock_response['Payload'].read.return_value = json.dumps({"tracking_id": "test-tracking-123"}).encode()
+    mock_lambda_client.invoke.return_value = mock_response
+    
+    # Call the function
+    arn = "arn:aws:lambda:us-east-1:123456789012:function:test-function"
+    tracking_id = producer.send_to_producer_via_arn(arn, valid_message)
+    
+    # Verify the result
+    assert tracking_id == "test-tracking-123"
+    
+    # Verify boto3 client was called correctly
+    mock_boto3_client.assert_called_once_with('lambda', region_name='ap-southeast-2')
+    mock_lambda_client.invoke.assert_called_once_with(
+        FunctionName=arn,
+        InvocationType='RequestResponse',
+        Payload=json.dumps(valid_message)
+    )
+
+
+@patch('boto3.client')
+def test_arn_lambda_invocation_api_gateway_response(mock_boto3_client, valid_message):
+    """Test successful Lambda invocation with API Gateway response format"""
+    # Mock the Lambda client and its invoke method
+    mock_lambda_client = MagicMock()
+    mock_boto3_client.return_value = mock_lambda_client
+    
+    # Mock successful response with API Gateway format
+    api_gateway_response = {
+        'statusCode': 200,
+        'body': json.dumps({"tracking_id": "api-gateway-tracking-456"})
+    }
+    mock_response = {
+        'StatusCode': 200,
+        'Payload': MagicMock()
+    }
+    mock_response['Payload'].read.return_value = json.dumps(api_gateway_response).encode()
+    mock_lambda_client.invoke.return_value = mock_response
+    
+    # Call the function
+    arn = "arn:aws:lambda:us-east-1:123456789012:function:test-function"
+    tracking_id = producer.send_to_producer_via_arn(arn, valid_message)
+    
+    # Verify the result
+    assert tracking_id == "api-gateway-tracking-456"
+
+
+@patch('boto3.client')
+def test_arn_lambda_invocation_failure(mock_boto3_client, valid_message):
+    """Test Lambda invocation failure handling"""
+    # Mock the Lambda client and its invoke method
+    mock_lambda_client = MagicMock()
+    mock_boto3_client.return_value = mock_lambda_client
+    
+    # Mock failed response
+    mock_response = {
+        'StatusCode': 500,
+        'Payload': MagicMock()
+    }
+    mock_response['Payload'].read.return_value = json.dumps({"errorMessage": "Internal error"}).encode()
+    mock_lambda_client.invoke.return_value = mock_response
+    
+    # Call the function and expect RuntimeError
+    arn = "arn:aws:lambda:us-east-1:123456789012:function:test-function"
+    with pytest.raises(RuntimeError) as exc_info:
+        producer.send_to_producer_via_arn(arn, valid_message)
+    
+    assert "Lambda invocation failed with status: 500" in str(exc_info.value)
+
+
+@patch('boto3.client')
+def test_arn_lambda_api_gateway_error_response(mock_boto3_client, valid_message):
+    """Test API Gateway error response handling"""
+    # Mock the Lambda client and its invoke method
+    mock_lambda_client = MagicMock()
+    mock_boto3_client.return_value = mock_lambda_client
+    
+    # Mock API Gateway error response
+    api_gateway_error = {
+        'statusCode': 400,
+        'body': json.dumps({"error": "Bad Request"})
+    }
+    mock_response = {
+        'StatusCode': 200,
+        'Payload': MagicMock()
+    }
+    mock_response['Payload'].read.return_value = json.dumps(api_gateway_error).encode()
+    mock_lambda_client.invoke.return_value = mock_response
+    
+    # Call the function and expect RuntimeError
+    arn = "arn:aws:lambda:us-east-1:123456789012:function:test-function"
+    with pytest.raises(RuntimeError) as exc_info:
+        producer.send_to_producer_via_arn(arn, valid_message)
+    
+    assert "Failed to send message: 400" in str(exc_info.value)
+
+
+@patch('boto3.client')
+def test_arn_boto3_exception_handling(mock_boto3_client, valid_message):
+    """Test boto3 exception handling"""
+    # Mock the Lambda client to raise an exception
+    mock_lambda_client = MagicMock()
+    mock_boto3_client.return_value = mock_lambda_client
+    mock_lambda_client.invoke.side_effect = Exception("AWS credentials not found")
+    
+    # Call the function and expect RuntimeError
+    arn = "arn:aws:lambda:us-east-1:123456789012:function:test-function"
+    with pytest.raises(RuntimeError) as exc_info:
+        producer.send_to_producer_via_arn(arn, valid_message)
+    
+    assert "Failed to invoke Lambda function: AWS credentials not found" in str(exc_info.value)
+
+
+@pytest.mark.skipif(PRODUCER_ARN is None, reason="KINDO_MESSAGE_PRODUCER_ARN not set")
+def test_arn_integration_success(valid_message):
+    """Integration test for ARN function with real AWS Lambda"""
+    tracking_id = producer.send_to_producer_via_arn(PRODUCER_ARN, valid_message)
+    assert isinstance(tracking_id, str) and len(tracking_id) > 0
+
+
+
 


### PR DESCRIPTION
URL based invocation is only used for local devleopment purposes and not for production since it won't be able to reach private VPC.

ARN based invocation will be available for production environment purposes and will work within private vpc

This PR adds a way to invoke lambda via ARN.