### PR TITLE
Fix schema path and validation

### DIFF
--- a/clients/python/producer.py
+++ b/clients/python/producer.py
@@ -51,10 +51,23 @@ def send_to_producer_via_arn(
     arn: str,
     message: ProducerPayload,
     region: str = AWS_REGION,
-    schema_path: str = SCHEMA_PATH
 ) -> str:
-    with open(os.path.join(os.path.dirname(__file__), schema_path)) as f:
-        schema = json.load(f)
+    # Set default security_level if not provided
+    if "security_level" not in message:
+        message["security_level"] = "normal"
+    
+    # Load schema from package resources or local file
+    try:
+        # First try to load from package-local schemas (for installed package)
+        schema_path = os.path.join(os.path.dirname(__file__), 'schemas/producer_payload.json')
+        with open(schema_path) as f:
+            schema = json.load(f)
+    except Exception:
+        # Fallback to project root schemas (for development)
+        schema_path = os.path.join(os.path.dirname(__file__), SCHEMA_PATH)
+        with open(schema_path) as f:
+            schema = json.load(f)
+    
     try:
         jsonschema.validate(instance=message, schema=schema)
     except jsonschema.ValidationError as e:


### PR DESCRIPTION
Reuse schema validation code from send_to_producer.

Encountered this error when trying to use new send_to_producer_via_arn function
<img width="1168" height="47" alt="Screenshot 2025-07-15 at 11 19 34 AM" src="https://github.com/user-attachments/assets/5cfef6ec-2194-4dc7-80c1-0453ce047b06" />
